### PR TITLE
fixes #58 – popup with many layers

### DIFF
--- a/js/src/controls/control.chart.js
+++ b/js/src/controls/control.chart.js
@@ -94,6 +94,7 @@ Wu.Control.Chart = Wu.Control.extend({
 
 	updateExistingPopup : function (options) {
 
+
 		var popup = options.context._chart._popup;
 
 		var e = options.e;
@@ -237,6 +238,7 @@ Wu.Control.Chart = Wu.Control.extend({
 	// Create "normal" pop-up content without time series
 	_createPopupContent : function (e) {
 
+		this.popupSettings = e.layer.getTooltip();
 
 		var c3Obj = {
 			data : e.data,
@@ -257,6 +259,7 @@ Wu.Control.Chart = Wu.Control.extend({
 		}
 
 		this._c3Obj = this.createC3dataObj(c3Obj);
+	
 
 		var headerOptions = {
 			headerMeta 	: this._c3Obj.d3array.meta,
@@ -283,6 +286,8 @@ Wu.Control.Chart = Wu.Control.extend({
 
 
 	singleC3PopUp : function (e) {
+
+
 
 		var c3Obj = {
 			data : e.data,

--- a/js/src/controls/control.tooltip.js
+++ b/js/src/controls/control.tooltip.js
@@ -52,11 +52,9 @@ Wu.Tooltip = Wu.Class.extend({
 		this._isActive() ? this.on() : this.off();
 	},
 
-	on : function () { 				
-		return;
-		// console.error('tooltip on!'); // todo optimize: too many event registered?
+	on : function () {
 
-		// console.log('on tips!', this.tips);
+		return;
 
 		// create tooltip
 		this.tips.forEach(function (t) {


### PR DESCRIPTION
The whole popup kind of needs a rewriting. It's currently split into three files: `popup.chart.js`, `control.chart.js` and `control.tooltip.js`

I suggest that we keep it like it is for now, and look into it more when we need to build more functions for grid layer click – such as other graphs, etc (specifically mentioned by InsightOne AS).
